### PR TITLE
Fix balloon text color var

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -44,9 +44,8 @@ button[aria-label] {
 
       background: var(--balloon-color);
       border-radius: 2px;
-      color: var(--balloon-foreground-color);
+      color: var(--balloon-text-color);
       border-radius: var(--balloon-border-radius);
-      color: var(--balloon-foreground-color);
       content: attr(aria-label);
       padding: .5em 1em;
       position: absolute;


### PR DESCRIPTION
Remove duplicate declaration and use the correct variable (--balloon-text-color) in favour of --balloon-foreground-color. Otherwise this doesn't compile to CSS without inheriting the colour of the parent. 